### PR TITLE
Set SSRC to Node ID, not to a counter

### DIFF
--- a/helper/mcptt-helper.cc
+++ b/helper/mcptt-helper.cc
@@ -115,16 +115,6 @@ McpttHelper::EnableLogComponents()
     LogComponentEnable("McpttOnNetworkCallMachineClientState", LOG_LEVEL_ALL);
 }
 
-uint32_t
-McpttHelper::GetNextUserId()
-{
-    static uint32_t s_nextUserId = 0;
-
-    s_nextUserId += 1;
-
-    return s_nextUserId;
-}
-
 McpttHelper::McpttHelper()
     : m_pushConfigured(false),
       m_releaseConfigured(false)
@@ -339,8 +329,6 @@ McpttHelper::SetPusherPttDurationVariable(std::string name,
 Ptr<Application>
 McpttHelper::InstallPriv(const Ptr<Node>& node)
 {
-    uint32_t userId = McpttHelper::GetNextUserId();
-
     Ptr<McpttPttApp> app = m_appFac.Create<McpttPttApp>();
     Ptr<McpttMediaSrc> requester = m_mediaSrcFac.Create<McpttMediaSrc>();
     Ptr<McpttPusher> pusher = m_pusherFac.Create<McpttPusher>();
@@ -357,7 +345,7 @@ McpttHelper::InstallPriv(const Ptr<Node>& node)
                              PointerValue(m_pusherReleaseFac.Create<RandomVariableStream>()));
     }
 
-    app->SetUserId(userId);
+    app->SetUserId(node->GetId());
     app->SetMediaSrc(requester);
     app->SetPusher(pusher);
 

--- a/helper/mcptt-helper.h
+++ b/helper/mcptt-helper.h
@@ -69,11 +69,6 @@ class McpttHelper
      */
     static void EnableLogComponents();
     /**
-     * \brief Gets the MCPTT ID that will be assigned to the next application that is created.
-     * \returns The MCPTT ID
-     */
-    static uint32_t GetNextUserId();
-    /**
      * \brief Creates an instance of the McpttHelper class.
      */
     McpttHelper();


### PR DESCRIPTION
The current approach of using a counter (static variable) to set SSRC will lead to misalignment between SSRC and Node ID when the containers passed into the helper are not ordered by node ID.  This can make the MCPTT traces hard to decipher.  For instance, in the WFPST paper scenarios, the relay node is assigned SSRC 8 despite being Node ID 5.