### PR TITLE
Added trace helpers for NetSimulyzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ set(source_files
     helper/mcptt-server-helper.cc
     helper/mcptt-state-machine-stats.cc
     helper/mcptt-trace-helper.cc
+    helper/netsim-mcptt-basic-group-charter.cc
+    helper/netsim-mcptt-basic-group-visualizer.cc
     helper/uav-mobility-energy-model-helper.cc
     helper/udp-group-echo-helper.cc
     model/intel-http-client.cc
@@ -111,6 +113,8 @@ set(header_files
     helper/mcptt-server-helper.h
     helper/mcptt-state-machine-stats.h
     helper/mcptt-trace-helper.h
+    helper/netsim-mcptt-basic-group-charter.h
+    helper/netsim-mcptt-basic-group-visualizer.h
     helper/uav-mobility-energy-model-helper.h
     helper/udp-group-echo-helper.h
     model/intel-http-client.h
@@ -204,6 +208,11 @@ set(test_sources
     test/uav-mobility-energy-model-test.cc
     )
 
+set(additional_libs_to_link "")
+if(HAS_NETSIMULYZER)
+  list(APPEND additional_libs_to_link ${libnetsimulyzer})
+endif()
+
 build_lib(
     LIBNAME psc
     SOURCE_FILES ${source_files}
@@ -218,4 +227,5 @@ build_lib(
     ${libnetwork}
     ${libpoint-to-point}
     ${libsip}
+    ${additional_libs_to_link}
 )

--- a/helper/netsim-mcptt-basic-group-charter.cc
+++ b/helper/netsim-mcptt-basic-group-charter.cc
@@ -1,0 +1,324 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * NIST-developed software is provided by NIST as a public
+ * service. You may use, copy and distribute copies of the software in
+ * any medium, provided that you keep intact this entire notice. You
+ * may improve, modify and create derivative works of the software or
+ * any portion of the software, and you may copy and distribute such
+ * modifications or works. Modified works should carry a notice
+ * stating that you changed the software and should note the date and
+ * nature of any such change. Please explicitly acknowledge the
+ * National Institute of Standards and Technology as the source of the
+ * software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES
+ * NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT OR ARISING BY
+ * OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ * NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+ * WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+ * OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT
+ * WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+ * SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+ * CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of
+ * using and distributing the software and you assume all risks
+ * associated with its use, including but not limited to the risks and
+ * costs of program errors, compliance with applicable laws, damage to
+ * or loss of data, programs or equipment, and the unavailability or
+ * interruption of operation. This software is not intended to be used
+ * in any situation where a failure could cause risk of injury or
+ * damage to property. The software developed by NIST employees is not
+ * subject to copyright protection within the United States.
+ *
+ * Author: Nihar Kapasi <niharkkapasi@gmail.com>
+ */
+
+#ifdef HAS_NETSIMULYZER
+
+#include "netsim-mcptt-basic-group-charter.h"
+
+#include <ns3/boolean.h>
+
+namespace ns3
+{
+
+namespace psc
+{
+
+NS_LOG_COMPONENT_DEFINE("NetSimMcpttPttBasicGroupCharter");
+
+using namespace std;
+
+int
+NetSimMcpttPttBasicGroupCharter::SetUp(Ptr<netsimulyzer::Orchestrator> orchestrator)
+{
+    // Setup already occured
+    if (m_isSetUp)
+    {
+        return 0;
+    }
+
+    if (orchestrator == nullptr)
+    {
+        m_isSetUp = false;
+        return -1;
+    }
+
+    m_orchestrator = orchestrator;
+    LinkTraces();
+    m_isSetUp = true;
+    return 1;
+}
+
+void
+NetSimMcpttPttBasicGroupCharter::SetUpGraphCollections()
+{
+    // Method already called once. Skip collection setup
+    if (m_areGraphsSetUp)
+    {
+        return;
+    }
+
+    PointerValue xAxis;
+    PointerValue yAxis;
+
+    // Collection of AccessTime Ecdf graphs over all groups
+    m_accessTimeEcdfCollection = CreateObject<netsimulyzer::SeriesCollection>(m_orchestrator);
+    m_accessTimeEcdfCollection->SetAttribute("Name",
+                                             StringValue("Access time - eCDF - All groups"));
+    m_accessTimeEcdfCollection->GetAttribute("XAxis", xAxis);
+    xAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Access time (ms)"));
+    m_accessTimeEcdfCollection->GetAttribute("YAxis", yAxis);
+    yAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Empirical CDF"));
+    m_accessTimeEcdfCollection->SetAttribute("HideAddedSeries", BooleanValue(false));
+
+    // Collection of M2eLatency Ecdf graphs over all groups
+    m_m2eLatencyEcdfCollection = CreateObject<netsimulyzer::SeriesCollection>(m_orchestrator);
+    m_m2eLatencyEcdfCollection->SetAttribute("Name",
+                                             StringValue("M2E latency - eCDF - All groups"));
+    m_m2eLatencyEcdfCollection->GetAttribute("XAxis", xAxis);
+    xAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("M2E latency (ms)"));
+    m_m2eLatencyEcdfCollection->GetAttribute("YAxis", yAxis);
+    yAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Empirical CDF"));
+    m_m2eLatencyEcdfCollection->SetAttribute("HideAddedSeries", BooleanValue(false));
+
+    // Collection of AccessTime Timelin graphs over all groups
+    m_accessTimeTimelineCollection = CreateObject<netsimulyzer::SeriesCollection>(m_orchestrator);
+    m_accessTimeTimelineCollection->SetAttribute(
+        "Name",
+        StringValue("Access time - Timeline - All groups"));
+    m_accessTimeTimelineCollection->GetAttribute("XAxis", xAxis);
+    xAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Time (s)"));
+    m_accessTimeTimelineCollection->GetAttribute("YAxis", yAxis);
+    yAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Access time (ms)"));
+    m_accessTimeTimelineCollection->SetAttribute("HideAddedSeries", BooleanValue(false));
+
+    // Collection of M2eLatency Timelin graphs over all groups
+    m_m2eLatencyTimelineCollection = CreateObject<netsimulyzer::SeriesCollection>(m_orchestrator);
+    m_m2eLatencyTimelineCollection->SetAttribute(
+        "Name",
+        StringValue("M2E latency - Timeline - All groups"));
+    m_m2eLatencyTimelineCollection->GetAttribute("XAxis", xAxis);
+    xAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("Time (s)"));
+    m_m2eLatencyTimelineCollection->GetAttribute("YAxis", yAxis);
+    yAxis.Get<netsimulyzer::ValueAxis>()->SetAttribute("Name", StringValue("M2E latency (ms)"));
+    m_m2eLatencyTimelineCollection->SetAttribute("HideAddedSeries", BooleanValue(false));
+
+    m_areGraphsSetUp = true;
+}
+
+void
+NetSimMcpttPttBasicGroupCharter::LinkTraces()
+{
+    m_mcpttTraceHelper = CreateObject<McpttTraceHelper>();
+    m_mcpttTraceHelper->EnableAccessTimeTrace();
+    m_mcpttTraceHelper->EnableMouthToEarLatencyTrace();
+
+    m_mcpttTraceHelper->TraceConnectWithoutContext(
+        "AccessTimeTrace",
+        MakeCallback(&NetSimMcpttPttBasicGroupCharter::AccessTimeTrace, this));
+    m_mcpttTraceHelper->TraceConnectWithoutContext(
+        "MouthToEarLatencyTrace",
+        MakeCallback(&NetSimMcpttPttBasicGroupCharter::M2eLatencyTrace, this));
+}
+
+int
+NetSimMcpttPttBasicGroupCharter::AddGroup(ApplicationContainer pttApps,
+                                          uint32_t grpId,
+                                          netsimulyzer::Color3Value nextColor)
+{
+    if ((pttApps.GetN() < 2) || m_allGrpIds.contains(grpId) || (!m_isSetUp))
+    {
+        return -1;
+    }
+
+    // Set-up collection graphs if not done so already
+    // Called when adding the first group to be tracked
+    if (!m_areGraphsSetUp)
+    {
+        SetUpGraphCollections();
+        m_areGraphsSetUp = true;
+    }
+
+    // ECDFs for Access time
+    auto groupAccessTimeEcdf =
+        CreateObject<netsimulyzer::EcdfSink>(m_orchestrator,
+                                             "Access time - eCDF - " + std::to_string(grpId));
+    groupAccessTimeEcdf->GetXAxis()->SetAttribute("Name", StringValue("Access time (ms)"));
+    groupAccessTimeEcdf->GetYAxis()->SetAttribute("Name", StringValue("Emperical CDF"));
+    groupAccessTimeEcdf->GetSeries()->SetAttribute("Color", nextColor);
+    // groupAccessTimeEcdf->SetConnectionType(netsimulyzer::XYSeries::ConnectionType::None);
+    groupAccessTimeEcdf->GetSeries()->SetAttribute("Visible", BooleanValue(false));
+    m_accessTimeEcdfCollection->Add(groupAccessTimeEcdf->GetSeries());
+
+    // ECDFs for M2E latency
+    auto groupM2eLatencyEcdfs =
+        CreateObject<netsimulyzer::EcdfSink>(m_orchestrator,
+                                             "M2E latency - eCDF - " + std::to_string(grpId));
+    groupM2eLatencyEcdfs->GetXAxis()->SetAttribute("Name", StringValue("M2E latency (ms)"));
+    groupM2eLatencyEcdfs->GetYAxis()->SetAttribute("Name", StringValue("Emperical CDF"));
+    groupM2eLatencyEcdfs->GetSeries()->SetAttribute("Color", nextColor);
+    // groupM2eLatencyEcdfs->SetConnectionType(netsimulyzer::XYSeries::ConnectionType::None);
+    groupM2eLatencyEcdfs->GetSeries()->SetAttribute("Visible", BooleanValue(false));
+    m_m2eLatencyEcdfCollection->Add(groupM2eLatencyEcdfs->GetSeries());
+
+    // Timeline for Access time
+    auto groupAccessTimeTimeline = CreateObject<netsimulyzer::XYSeries>(m_orchestrator);
+    groupAccessTimeTimeline->SetAttribute(
+        "Name",
+        StringValue("Access time - Timeline - " + std::to_string(grpId)));
+    groupAccessTimeTimeline->SetAttribute("Color", nextColor);
+    groupAccessTimeTimeline->SetAttribute("Connection", StringValue("None"));
+    groupAccessTimeTimeline->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
+    groupAccessTimeTimeline->GetYAxis()->SetAttribute("Name", StringValue("Access time (ms)"));
+    groupAccessTimeTimeline->SetAttribute("Visible", BooleanValue(false));
+    m_accessTimeTimelineCollection->Add(groupAccessTimeTimeline);
+
+    // Timeline for M2E latency
+    auto groupM2eLatencyTimeline = CreateObject<netsimulyzer::XYSeries>(m_orchestrator);
+    groupM2eLatencyTimeline->SetAttribute(
+        "Name",
+        StringValue("M2E latency - Timeline - " + std::to_string(grpId)));
+    groupM2eLatencyTimeline->SetAttribute("Color", nextColor);
+    groupM2eLatencyTimeline->SetAttribute("Connection", StringValue("None"));
+    groupM2eLatencyTimeline->GetXAxis()->SetAttribute("Name", StringValue("Time (s)"));
+    groupM2eLatencyTimeline->GetYAxis()->SetAttribute("Name", StringValue("M2E latency (ms)"));
+    groupM2eLatencyTimeline->SetAttribute("Visible", BooleanValue(false));
+    m_m2eLatencyTimelineCollection->Add(groupM2eLatencyTimeline);
+
+    m_grpIdToAccessTimeTimelineSeries.insert(
+        std::pair<uint32_t, Ptr<netsimulyzer::XYSeries>>(grpId, groupAccessTimeTimeline));
+    m_grpIdToAccessTimeEcdf.insert(
+        std::pair<uint32_t, Ptr<netsimulyzer::EcdfSink>>(grpId, groupAccessTimeEcdf));
+    m_grpIdToM2eLatencyTimelineSeries.insert(
+        std::pair<uint32_t, Ptr<netsimulyzer::XYSeries>>(grpId, groupM2eLatencyTimeline));
+    m_grpIdToM2eLatencyEcdf.insert(
+        std::pair<uint32_t, Ptr<netsimulyzer::EcdfSink>>(grpId, groupM2eLatencyEcdfs));
+
+    for (uint32_t i = 0; i < pttApps.GetN(); i++)
+    {
+        auto app = DynamicCast<McpttPttApp>(pttApps.Get(i));
+        uint32_t userId = app->GetUserId();
+        uint32_t nodeId = app->GetNode()->GetId();
+
+        m_idsToAppPtr.insert(std::pair<uint32_t, Ptr<McpttPttApp>>(nodeId, app));
+        m_idsToAppPtr.insert(std::pair<uint32_t, Ptr<McpttPttApp>>(userId, app));
+    }
+
+    // Keeping track of all added grpIds
+    // Prevent user from reusing grpIds
+    m_allGrpIds.insert(grpId);
+    return 0;
+}
+
+void
+NetSimMcpttPttBasicGroupCharter::AccessTimeTrace(Time t,
+                                                 uint32_t userId,
+                                                 uint16_t callId,
+                                                 std::string result,
+                                                 Time latency)
+{
+    if ((!m_isSetUp) || (result != "I" && result != "Q"))
+    {
+        return;
+    }
+
+    int grpId = GetGroupId(userId, callId);
+    if (grpId != -1)
+    {
+        m_grpIdToAccessTimeTimelineSeries[grpId]->Append(Simulator::Now().GetSeconds(),
+                                                         latency.GetMilliSeconds());
+        m_grpIdToAccessTimeEcdf[grpId]->Append(latency.GetMilliSeconds());
+    }
+}
+
+void
+NetSimMcpttPttBasicGroupCharter::M2eLatencyTrace(Time t,
+                                                 uint32_t ssrc,
+                                                 uint64_t nodeId,
+                                                 uint16_t callId,
+                                                 Time latency)
+{
+    if (!m_isSetUp)
+    {
+        return;
+    }
+
+    int grpId = GetGroupId(nodeId, callId);
+    if (grpId != -1)
+    {
+        m_grpIdToM2eLatencyTimelineSeries[grpId]->Append(Simulator::Now().GetSeconds(),
+                                                         latency.GetMilliSeconds());
+        m_grpIdToM2eLatencyEcdf[grpId]->Append(latency.GetMilliSeconds());
+    }
+}
+
+int
+NetSimMcpttPttBasicGroupCharter::GetGroupId(uint32_t id, uint16_t callId)
+{
+    auto appPtrIt = m_idsToAppPtr.find(id);
+    if (appPtrIt == m_idsToAppPtr.end())
+    {
+        // Fetching grp id for a node whose app was not added through AddGroup
+        // Trace sinks are linked for all nodes in simulation and so is an expected condition to be
+        // ignored
+        NS_LOG_WARN("Fetching grp id for unadded app with userId/nodeId " + std::to_string(id) +
+                    "for call " + std::to_string(callId));
+        return -1;
+    }
+
+    ObjectMapValue callMap;
+    appPtrIt->second->GetAttribute("Calls", callMap);
+    for (auto callIt = callMap.Begin(); callIt != callMap.End(); callIt++)
+    {
+        auto call = DynamicCast<McpttCall>(callIt->second);
+        if (call->GetCallId() == callId)
+        {
+            auto callMachine = DynamicCast<McpttCallMachineGrp>(call->GetCallMachine());
+            uint32_t grpId = callMachine->GetGrpId().GetGrpId();
+            // Limit to groups that the user has added
+            if (m_allGrpIds.contains(grpId))
+            {
+                return grpId;
+            }
+
+            // Fetching grp id for a node whose app was not added through AddGroup
+            // Trace sinks are linked for all nodes in simulation and so is an expected condition to
+            // be ignored
+            NS_LOG_WARN("Fetching grp id for unadded app with userId/nodeId " + std::to_string(id) +
+                        "for call " + std::to_string(callId));
+            return -1;
+        }
+    }
+
+    NS_FATAL_ERROR("Grp id not found for call " + std::to_string(+callId) + "for userId/nodeId " +
+                   std::to_string(id));
+}
+
+} /* namespace psc */
+
+} /* namespace ns3 */
+
+#endif /* HAS_NETSIMULYZER */

--- a/helper/netsim-mcptt-basic-group-charter.h
+++ b/helper/netsim-mcptt-basic-group-charter.h
@@ -1,0 +1,198 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * NIST-developed software is provided by NIST as a public
+ * service. You may use, copy and distribute copies of the software in
+ * any medium, provided that you keep intact this entire notice. You
+ * may improve, modify and create derivative works of the software or
+ * any portion of the software, and you may copy and distribute such
+ * modifications or works. Modified works should carry a notice
+ * stating that you changed the software and should note the date and
+ * nature of any such change. Please explicitly acknowledge the
+ * National Institute of Standards and Technology as the source of the
+ * software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES
+ * NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT OR ARISING BY
+ * OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ * NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+ * WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+ * OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT
+ * WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+ * SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+ * CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of
+ * using and distributing the software and you assume all risks
+ * associated with its use, including but not limited to the risks and
+ * costs of program errors, compliance with applicable laws, damage to
+ * or loss of data, programs or equipment, and the unavailability or
+ * interruption of operation. This software is not intended to be used
+ * in any situation where a failure could cause risk of injury or
+ * damage to property. The software developed by NIST employees is not
+ * subject to copyright protection within the United States.
+ *
+ * Author: Nihar Kapasi <niharkkapasi@gmail.com>
+ */
+
+#ifndef NETSIM_MCPTT_BASIC_GROUP_CHARTER
+#define NETSIM_MCPTT_BASIC_GROUP_CHARTER
+
+#ifdef HAS_NETSIMULYZER
+
+#include <ns3/mcptt-ptt-app.h>
+#include <ns3/mcptt-trace-helper.h>
+
+#include <ns3/application-container.h>
+#include <ns3/color.h>
+#include <ns3/ecdf-sink.h>
+#include <ns3/object-map.h>
+#include <ns3/orchestrator.h>
+#include <ns3/packet.h>
+#include <ns3/series-collection.h>
+#include <ns3/type-id.h>
+#include <ns3/xy-series.h>
+
+namespace ns3
+{
+
+namespace psc
+{
+
+using namespace std;
+
+/*
+ * Create Timeline and Ecdf graphs for (displayed in SeriesCollection as curves per grp):
+ * - M2eLatency
+ * - AccessTime (only limits to result of I/Q)
+ *
+ * Usage: First call SetUp()
+ *        then AddGroup for each basic group you wish to enable tracing for
+ * ASSUMPTION: Only one McpttPttApp per node (to change could have a list of McpttPttApps per node
+ *                                            and iterate through that in GetGrpId() method)
+ * ASSUMPTION: call ids are globally unique (ensured by McpttServerApp::AllocateId in
+ * McpttCallHelper) ASSUMPTION: user ids are unique per app (ensured by McpttHelper)
+ */
+class NetSimMcpttPttBasicGroupCharter
+{
+  public:
+    NetSimMcpttPttBasicGroupCharter() = default;
+
+    /*
+     *
+     * \returns 1 on success
+     *          0 (returns immediately) on recall after succesfull setup
+     *          -1 unsuccessful setup (orchestrator = nullptr)
+     */
+    int SetUp(Ptr<netsimulyzer::Orchestrator> orchestrator);
+
+    /*
+     * Method to add group for tracing
+     * ASSUMPTION: pttApps are all part of the same group
+     * \param grpId - the group id used in the McpttCallHelper::AddCall/AddCallOffNetwork
+     * \param nextColor - the color to be used for the graphs associated with this group
+     * \returns 1 on success
+     *          -1 on failure (#pttApps < 2 | grpId < 0 | reusing a grpId)
+     */
+    int AddGroup(ApplicationContainer pttApps, uint32_t grpId, netsimulyzer::Color3Value nextColor);
+
+  private:
+    /*
+     * Links to AccessTime and M2eLatency trace sources of McpttTraceSources
+     * This links to all nodes in the simulation
+     * As a result other methods will check again other private maps to ensure that
+     * data being fetched is only for nodes/apps added via AddGroup
+     */
+    void LinkTraces();
+
+    /*
+     * Sets up the series collections for time series and ecdf graphs
+     */
+    void SetUpGraphCollections();
+
+    /*
+     * \param id The globally unique user id or node id
+     * \return the group id associated with the particular id, callId pair
+     */
+    int GetGroupId(uint32_t id, uint16_t callId);
+
+    /*
+     * Trace sink to update AccessTime related graphs
+     */
+    void AccessTimeTrace(Time t,
+                         uint32_t userId,
+                         uint16_t callId,
+                         std::string result,
+                         Time latency);
+
+    /*
+     * Trace sink to update M2eLatency related graphs
+     */
+    void M2eLatencyTrace(Time t, uint32_t ssrc, uint64_t nodeId, uint16_t callId, Time latency);
+
+    /*
+     * Boolean flag to denote successful setup
+     */
+    bool m_isSetUp = false;
+    /*
+     * Boolean flag to denote SeriesCollections are made
+     */
+    bool m_areGraphsSetUp = false;
+    /*
+     * Orchestrator to be used to make graphs
+     */
+    Ptr<netsimulyzer::Orchestrator> m_orchestrator;
+    /*
+     * Trace helper to hook to the M2e and AccessTime trace sources
+     */
+    Ptr<McpttTraceHelper> m_mcpttTraceHelper;
+    /*
+     * Maps McpttPttApp user ids and node ids to the corresponding McpttPttApp
+     */
+    std::map<uint32_t, Ptr<McpttPttApp>> m_idsToAppPtr;
+    /*
+     * Set of all group ids
+     * Prevent users fo=rom reusing group id
+     */
+    std::set<uint32_t> m_allGrpIds;
+    /*
+     * Maps a grpId to its AccessTime Timeline graph
+     */
+    std::map<uint32_t, Ptr<netsimulyzer::XYSeries>> m_grpIdToAccessTimeTimelineSeries;
+    /*
+     * Maps a grpId to its AccessTime Ecdf graph
+     */
+    std::map<uint32_t, Ptr<netsimulyzer::EcdfSink>> m_grpIdToAccessTimeEcdf;
+    /*
+     * Maps a grpId to its M2eLatency Timeline graph
+     */
+    std::map<uint32_t, Ptr<netsimulyzer::XYSeries>> m_grpIdToM2eLatencyTimelineSeries;
+    /*
+     * Maps a grpId to its M2eLatency Ecdf graph
+     */
+    std::map<uint32_t, Ptr<netsimulyzer::EcdfSink>> m_grpIdToM2eLatencyEcdf;
+    /*
+     * Collection of AccessTime Ecdf graphs for each grp
+     */
+    Ptr<netsimulyzer::SeriesCollection> m_accessTimeEcdfCollection;
+    /*
+     * Collection of AccessTime Timeline graphs for each grp
+     */
+    Ptr<netsimulyzer::SeriesCollection> m_accessTimeTimelineCollection;
+    /*
+     * Collection of M2eLatency Ecdf graphs for each grp
+     */
+    Ptr<netsimulyzer::SeriesCollection> m_m2eLatencyEcdfCollection;
+    /*
+     * Collection of M2eLatency Timeline graphs for each grp
+     */
+    Ptr<netsimulyzer::SeriesCollection> m_m2eLatencyTimelineCollection;
+};
+
+} // namespace psc
+
+} // namespace ns3
+
+#endif /* HAS_NETSIMULYZER */
+
+#endif /* NETSIM_MCPTT_BASIC_GROUP_CHARTER */

--- a/helper/netsim-mcptt-basic-group-visualizer.cc
+++ b/helper/netsim-mcptt-basic-group-visualizer.cc
@@ -1,0 +1,139 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * NIST-developed software is provided by NIST as a public
+ * service. You may use, copy and distribute copies of the software in
+ * any medium, provided that you keep intact this entire notice. You
+ * may improve, modify and create derivative works of the software or
+ * any portion of the software, and you may copy and distribute such
+ * modifications or works. Modified works should carry a notice
+ * stating that you changed the software and should note the date and
+ * nature of any such change. Please explicitly acknowledge the
+ * National Institute of Standards and Technology as the source of the
+ * software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES
+ * NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT OR ARISING BY
+ * OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ * NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+ * WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+ * OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT
+ * WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+ * SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+ * CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of
+ * using and distributing the software and you assume all risks
+ * associated with its use, including but not limited to the risks and
+ * costs of program errors, compliance with applicable laws, damage to
+ * or loss of data, programs or equipment, and the unavailability or
+ * interruption of operation. This software is not intended to be used
+ * in any situation where a failure could cause risk of injury or
+ * damage to property. The software developed by NIST employees is not
+ * subject to copyright protection within the United States.
+ *
+ * Author: Nihar Kapasi <niharkkapasi@gmail.com>
+ */
+
+#ifdef HAS_NETSIMULYZER
+
+#include "netsim-mcptt-basic-group-visualizer.h"
+
+#include "ns3/mcptt-floor-msg.h"
+#include "ns3/mcptt-media-msg.h"
+#include "ns3/mcptt-ptt-app.h"
+
+#include <ns3/node-configuration.h>
+
+namespace ns3
+{
+
+namespace psc
+{
+
+NS_LOG_COMPONENT_DEFINE("NetSimMcpttPttBasicGroupVisualizer");
+
+using namespace std;
+
+int
+NetSimMcpttPttBasicGroupVisualizer::EnableVisualizations(
+    Ptr<netsimulyzer::Orchestrator> orchestrator,
+    ApplicationContainer pttApps,
+    netsimulyzer::Color3 highlightColor)
+{
+    if (m_isSetUp)
+    {
+        return 0;
+    }
+
+    bool areParamsWrong = (!orchestrator || !pttApps.GetN());
+    NS_ABORT_MSG_IF(areParamsWrong, "orchestrator null or #apps = 0");
+
+    m_orchestrator = orchestrator;
+    m_highlightColor = highlightColor;
+    LinkTraces(pttApps);
+    m_isSetUp = true;
+    return 1;
+}
+
+void
+NetSimMcpttPttBasicGroupVisualizer::LinkTraces(ApplicationContainer pttApps)
+{
+    for (uint32_t i = 0; i < pttApps.GetN(); i++)
+    {
+        auto node = pttApps.Get(i)->GetNode();
+        auto nodeConfig = node->GetObject<netsimulyzer::NodeConfiguration>();
+
+        m_nodeToColor.insert(
+            std::pair<uint32_t, netsimulyzer::Color3>{node->GetId(),
+                                                      nodeConfig->GetHighlightColor().value()});
+
+        Ptr<McpttPttApp> app = DynamicCast<McpttPttApp>(pttApps.Get(i));
+        app->TraceConnectWithoutContext(
+            "TxTrace",
+            MakeCallback(&NetSimMcpttPttBasicGroupVisualizer::McpttPttAppTxRxTraceCallback,
+                         this,
+                         true));
+    }
+}
+
+void
+NetSimMcpttPttBasicGroupVisualizer::McpttPttAppTxRxTraceCallback(bool isTx,
+                                                                 Ptr<const Application> app,
+                                                                 uint16_t callId,
+                                                                 Ptr<const Packet> packet,
+                                                                 const TypeId& headerType)
+{
+    if (!isTx)
+    {
+        return;
+    }
+
+    auto node = app->GetNode();
+    auto nodeConfig = node->GetObject<netsimulyzer::NodeConfiguration>();
+    auto it = m_nodeToColor.find(node->GetId());
+    NS_ABORT_MSG_IF((it == m_nodeToColor.end()),
+                    "Node with id" + std::to_string(node->GetId()) +
+                        "not found. Possibly due to unadded app during setup.");
+
+    // TODO: Support additional cases (e.g.: floor revoke)
+    // Node has relinquished the floor - highlight in original color
+    if ((headerType.IsChildOf(McpttFloorMsg::GetTypeId())) &&
+        (headerType.GetName().find("McpttFloorMsgRelease") != std::string::npos))
+    {
+        nodeConfig->SetHighlightColor(it->second);
+    }
+    // Node took the floor/started transmitting messages - turn on highlight
+    else if ((headerType == McpttMediaMsg::GetTypeId()) ||
+             ((headerType.IsChildOf(McpttFloorMsg::GetTypeId())) &&
+              (headerType.GetName().find("McpttFloorMsgTaken") != std::string::npos)))
+    {
+        nodeConfig->SetHighlightColor(m_highlightColor);
+    }
+}
+
+} /* namespace psc */
+
+} /* namespace ns3 */
+
+#endif /* HAS_NETSIMULYZER */

--- a/helper/netsim-mcptt-basic-group-visualizer.h
+++ b/helper/netsim-mcptt-basic-group-visualizer.h
@@ -1,0 +1,128 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * NIST-developed software is provided by NIST as a public
+ * service. You may use, copy and distribute copies of the software in
+ * any medium, provided that you keep intact this entire notice. You
+ * may improve, modify and create derivative works of the software or
+ * any portion of the software, and you may copy and distribute such
+ * modifications or works. Modified works should carry a notice
+ * stating that you changed the software and should note the date and
+ * nature of any such change. Please explicitly acknowledge the
+ * National Institute of Standards and Technology as the source of the
+ * software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES
+ * NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT OR ARISING BY
+ * OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ * NON-INFRINGEMENT AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+ * WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+ * OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT
+ * WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+ * SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+ * CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of
+ * using and distributing the software and you assume all risks
+ * associated with its use, including but not limited to the risks and
+ * costs of program errors, compliance with applicable laws, damage to
+ * or loss of data, programs or equipment, and the unavailability or
+ * interruption of operation. This software is not intended to be used
+ * in any situation where a failure could cause risk of injury or
+ * damage to property. The software developed by NIST employees is not
+ * subject to copyright protection within the United States.
+ *
+ * Author: Nihar Kapasi <niharkkapasi@gmail.com>
+ */
+
+#ifndef NETSIM_MCPTT_BASIC_GROUP_VISUALIZER
+#define NETSIM_MCPTT_BASIC_GROUP_VISUALIZER
+
+#ifdef HAS_NETSIMULYZER
+
+#include <ns3/application-container.h>
+#include <ns3/color.h>
+#include <ns3/orchestrator.h>
+#include <ns3/packet.h>
+#include <ns3/type-id.h>
+
+namespace ns3
+{
+
+namespace psc
+{
+
+using namespace std;
+
+/*
+ * Mcptt visualizer that highlights user when transmitting/taken the floor
+ * Currently does not support different highlight colors per group
+ * Multiple groups can be supported by either making an object per group or just passing in all apps
+ * in setup (TODO: change node to color map to use node Id, group Id pairs as keys and change
+ * m_highlightColor to map of grpIds to highlight color if want better support for group-specific
+ * colors)
+ *
+ * Usage: Only need to call EnableVisualizations
+ */
+class NetSimMcpttPttBasicGroupVisualizer
+{
+  public:
+    NetSimMcpttPttBasicGroupVisualizer() = default;
+
+    /*
+     * Method to enable netsimulyzer visualization features
+     * \param pttApps the apps to add visualization to
+     * \param highlightColor the color to highlight nodes that have taken floor/transmitting
+     * messages
+     * \return 1 on successful setup, 0 (immediately) on recall after successfull setup,
+     * -1 on unsuccessful setup (orchestrator = nullptr | #pttApps = 0)
+     *
+     * ASSUMPTION: pttApps does not include the server node
+     */
+    int EnableVisualizations(Ptr<netsimulyzer::Orchestrator> orchestrator,
+                             ApplicationContainer pttApps,
+                             netsimulyzer::Color3 highlightColor = netsimulyzer::RED);
+
+  private:
+    /*
+     * Method to link to rx/tx traces of the mcptt-ptt app to keep track of mcptt msgs
+     * Msgs used to toggle highlighting of nodes
+     */
+    void LinkTraces(ApplicationContainer pttApps);
+
+    /*
+     * Trace sink for McptPttApp tx trace to toggle logical links
+     * McpttPttApp have same callback signature for Tx and Rx (first parameter used to
+     * differentiate)
+     */
+    void McpttPttAppTxRxTraceCallback(bool isTx,
+                                      Ptr<const Application> app,
+                                      uint16_t callId,
+                                      Ptr<const Packet> packet,
+                                      const TypeId& headerType);
+
+    /*
+     * Boolean flag to denote successful setup
+     */
+    bool m_isSetUp = false;
+    /*
+     * Orchestrator used to create logical links
+     */
+    Ptr<netsimulyzer::Orchestrator> m_orchestrator;
+    /*
+     * Maps a node Id to its original highlight color
+     */
+    std::map<uint32_t, netsimulyzer::Color3> m_nodeToColor;
+    /*
+     * Highlight color to denote node as transmitting/taken floor
+     */
+    netsimulyzer::Color3 m_highlightColor;
+};
+
+} /* namespace psc */
+
+} /* namespace ns3 */
+
+#endif /* HAS_NETSIMULYZER */
+
+#endif /* NETSIM_MCPTT_BASIC_GROUP_VISUALIZER */


### PR DESCRIPTION
 One tracer to highlight nodes that are talking/taken floor in mcptt grp call
 One tracer to get AccessTime M2eLatency Timeline and Ecdf graphs aggregated per group
 Also edited CMakeLists to safely include netsimulyzer via the HAS_NETSIMULYZER macro