### PR TITLE
Update `HAS_PSC` to use variable for target name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ build_lib(
     ${additional_libs_to_link}
 )
 
-target_compile_definitions(libpsc PUBLIC HAS_PSC)
+target_compile_definitions(${libpsc} PUBLIC HAS_PSC)
 
 # This seems to only work with core modules if it's a cached value
 set(HAS_PSC TRUE CACHE BOOL "psc ns-3 module")


### PR DESCRIPTION
ns-3.43 seems to have changed the way these targets are named. Since the targets a re no longer named 'libX', this no longer works. Update this to use the variable version of the name, which should be forwards (hopefully) & backwards compatible